### PR TITLE
Replace travisci with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with: { bundler-cache: true }
+      - run: rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,15 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 2.6, 2.7, 3.0, 3.1, head ]
+
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
-        with: { bundler-cache: true }
-      - run: rake spec
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ 2.6, 2.7, 3.0, 3.1, head ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.6.3
-before_install: gem install bundler -v 1.11.2

--- a/graphiti_spec_helpers.gemspec
+++ b/graphiti_spec_helpers.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "actionpack", "~> 5.0"
-  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 13"
 end

--- a/graphiti_spec_helpers.gemspec
+++ b/graphiti_spec_helpers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "actionpack", "~> 5.0"
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency "rspec", "~> 3.0"
 end

--- a/graphiti_spec_helpers.gemspec
+++ b/graphiti_spec_helpers.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "graphiti", '>= 1.0.alpha.1'
+  spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "actionpack", "~> 5.0"
   spec.add_development_dependency "bundler", "~> 2"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 13"
 end


### PR DESCRIPTION
Runs tests on github actions across the same matrix of ruby versions as graphiti itself.